### PR TITLE
Fix build issue with RHEL 9.1 

### DIFF
--- a/driver/adv_main.c
+++ b/driver/adv_main.c
@@ -171,11 +171,12 @@ long adv_proc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 #include "./legacy/main/adv_proc_ioctl.h"
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
 int adv_proc_open(struct inode *inode, struct file *filp)
 {
 	struct adv_vcom * data;
 	
-	data = PDE_DATA(inode);
+	data = pde_data(inode);
 	filp->private_data = data;
 
 	return 0;
@@ -185,10 +186,13 @@ int adv_proc_release(struct inode *inode, struct file *filp)
 {
 	struct adv_vcom * data;
 
-	data = PDE_DATA(inode);
+	data = pde_data(inode);
 
 	return 0;
 }
+#else
+#include "./legacy/main/adv_proc_open.h"
+#endif
 
 unsigned int adv_proc_poll(struct file *filp, poll_table *wait)
 {

--- a/driver/legacy/main/adv_proc_open.h
+++ b/driver/legacy/main/adv_proc_open.h
@@ -1,0 +1,36 @@
+#ifndef ADV_PROC_OPEN_H
+#define ADV_PROC_OPEN_H
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+
+#else
+int adv_proc_open(struct inode *inode, struct file *filp)
+{
+	struct adv_vcom * data;
+#if defined(RHEL_RELEASE_CODE)
+#	if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,1)
+	data = pde_data(inode);
+#	else
+	data = PDE_DATA(inode);
+#	endif
+#endif
+
+	filp->private_data = data;
+	return 0;
+}
+
+int adv_proc_release(struct inode *inode, struct file *filp)
+{
+	struct adv_vcom * data;
+
+#if defined(RHEL_RELEASE_CODE)
+#	if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,1)
+	data = pde_data(inode);
+#	else
+	data = PDE_DATA(inode);
+#	endif
+#endif
+
+	return 0;
+}
+#endif
+#endif

--- a/driver/legacy/main/adv_proc_open.h
+++ b/driver/legacy/main/adv_proc_open.h
@@ -12,6 +12,8 @@ int adv_proc_open(struct inode *inode, struct file *filp)
 #	else
 	data = PDE_DATA(inode);
 #	endif
+#else
+	data = PDE_DATA(inode);
 #endif
 
 	filp->private_data = data;
@@ -28,6 +30,8 @@ int adv_proc_release(struct inode *inode, struct file *filp)
 #	else
 	data = PDE_DATA(inode);
 #	endif
+#else
+	data = PDE_DATA(inode);
 #endif
 
 	return 0;


### PR DESCRIPTION
Built on:

1. Ubuntu 20.04
2. Ubuntu 22.04
3. Rocky Linux(RHEL) 8.7
4. Rocky Linux(RHEL) 9.1


Waiting for stress test